### PR TITLE
fix: set default cell lengths to zero

### DIFF
--- a/src/dcdplugin.c
+++ b/src/dcdplugin.c
@@ -949,7 +949,8 @@ static int read_next_timestep(void *v, int natoms, molfile_timestep_t *ts) {
   dcdhandle *dcd;
   int i, j, rc;
   float unitcell[6];
-  unitcell[0] = unitcell[2] = unitcell[5] = 1.0f;
+  // default: infinite cell with lengths equal zero
+  unitcell[0] = unitcell[2] = unitcell[5] = 0.0f;
   unitcell[1] = unitcell[3] = unitcell[4] = 90.0f;
   dcd = (dcdhandle *)v;
 
@@ -1100,7 +1101,8 @@ static int write_timestep(void *v, const molfile_timestep_t *ts) {
   int i, rc, curstep;
   float *pos = ts->coords;
   double unitcell[6];
-  unitcell[0] = unitcell[2] = unitcell[5] = 1.0f;
+  // default: infinite cell with lengths equal zero
+  unitcell[0] = unitcell[2] = unitcell[5] = 0.0f;
   unitcell[1] = unitcell[3] = unitcell[4] = 90.0f;
 
   /* copy atom coords into separate X/Y/Z arrays for writing */

--- a/src/jsplugin.c
+++ b/src/jsplugin.c
@@ -1132,7 +1132,8 @@ static int read_js_timestep(void *v, int natoms, molfile_timestep_t *ts) {
     /* set unit cell pointer to the TS block-aligned buffer area */
     double *unitcell = (double *) js->directio_ucell_blkbuf;
 
-    unitcell[0] = unitcell[2] = unitcell[5] = 1.0f;
+    // default: infinite cell with lengths equal zero
+    unitcell[0] = unitcell[2] = unitcell[5] = 0.0f;
     unitcell[1] = unitcell[3] = unitcell[4] = 90.0f;
 
 #if defined(ENABLEJSSHORTREADS)


### PR DESCRIPTION
This allows chemfiles to detect missing unit cell information and set the shape to infinite.